### PR TITLE
Update argonaut-codecs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Utilities for generalizing rowtype encapsulations of kind Type
 
 ## Installation
 
-```
-bower install purescript-struct
+```sh
+spago install struct
 ```

--- a/bower.json
+++ b/bower.json
@@ -16,24 +16,24 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^4.2.0",
-    "purescript-effect": "^2.0.0",
-    "purescript-prelude": "^4.1.0",
+    "purescript-console": "^4.4.0",
+    "purescript-effect": "^2.0.1",
+    "purescript-prelude": "^4.1.1",
     "purescript-proxying": "^1.1.0",
-    "purescript-record": "^2.0.0",
-    "purescript-record-extra": "^3.0.0",
+    "purescript-record": "^2.0.2",
+    "purescript-record-extra": "^3.0.1",
     "purescript-subcategory": "^0.2.0",
-    "purescript-typelevel-prelude": "^5.0.0",
-    "purescript-variant": "^6.0.0"
+    "purescript-typelevel-prelude": "^5.0.2",
+    "purescript-variant": "^6.0.1"
   },
   "devDependencies": {
-    "purescript-argonaut-codecs": "^6.0.0",
-    "purescript-argonaut-core": "^5.0.0",
+    "purescript-argonaut-codecs": "^7.0.0",
+    "purescript-argonaut-core": "^5.0.2",
     "purescript-psci-support": "^4.0.0",
     "purescript-quickcheck": "^6.1.0",
     "purescript-test-unit": "^15.0.0"
   },
   "resolutions": {
-    "purescript-typelevel-prelude": "^5.0.0"
+    "purescript-typelevel-prelude": "^5.0.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,23 +17,23 @@
   ],
   "dependencies": {
     "purescript-console": "^4.4.0",
-    "purescript-effect": "^2.0.1",
-    "purescript-prelude": "^4.1.1",
+    "purescript-effect": "^2.0.0",
+    "purescript-prelude": "^4.1.0",
     "purescript-proxying": "^1.1.0",
-    "purescript-record": "^2.0.2",
-    "purescript-record-extra": "^3.0.1",
+    "purescript-record": "^2.0.0",
+    "purescript-record-extra": "^3.0.0",
     "purescript-subcategory": "^0.2.0",
-    "purescript-typelevel-prelude": "^5.0.2",
-    "purescript-variant": "^6.0.1"
+    "purescript-typelevel-prelude": "^5.0.0",
+    "purescript-variant": "^6.0.0"
   },
   "devDependencies": {
     "purescript-argonaut-codecs": "^7.0.0",
-    "purescript-argonaut-core": "^5.0.2",
+    "purescript-argonaut-core": "^5.0.0",
     "purescript-psci-support": "^4.0.0",
     "purescript-quickcheck": "^6.1.0",
     "purescript-test-unit": "^15.0.0"
   },
   "resolutions": {
-    "purescript-typelevel-prelude": "^5.0.2"
+    "purescript-typelevel-prelude": "^5.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,20 +1,13 @@
 {
   "name": "purescript-struct",
   "homepage": "https://github.com/matthew-hilty/purescript-struct",
-  "authors": [
-    "Matthew Hilty <hilty.matthew+purescript@gmail.com>"
-  ],
+  "authors": ["Matthew Hilty <hilty.matthew+purescript@gmail.com>"],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/matthew-hilty/purescript-struct.git"
   },
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "output"
-  ],
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
   "dependencies": {
     "purescript-console": "^4.4.0",
     "purescript-effect": "^2.0.0",
@@ -32,8 +25,5 @@
     "purescript-psci-support": "^4.0.0",
     "purescript-quickcheck": "^6.1.0",
     "purescript-test-unit": "^15.0.0"
-  },
-  "resolutions": {
-    "purescript-typelevel-prelude": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "repository": "https://github.com/matthew-hilty/purescript-struct",
   "author": "matthew.hilty <hilty.matthew@gmail.com>",
   "license": "MIT",
-  "private": true,
   "devDependencies": {
     "bower": "^1.8.8",
     "pulp": "^13.0.0"

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,33 +1,31 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/packages.dhall sha256:60cc03d2c3a99a0e5eeebb16a22aac219fa76fe6a1686e8c2bd7a11872527ea3
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
 let overrides = {=}
 
 let additions =
-  { proxying =
-      mkPackage
-        [ "console"
-        , "effect"
-        , "generics-rep"
-        , "prelude"
-        , "test-unit"
-        , "typelevel-prelude"
-        ]
-        "https://github.com/matthew-hilty/purescript-proxying.git"
-        "v1.1.0"
-  , subcategory =
-      mkPackage
-        [ "prelude"
-        , "profunctor"
-        , "proxy"
-        , "record"
-        , "typelevel-prelude"
-        ]
-        "https://github.com/matthew-hilty/purescript-subcategory.git"
-        "v0.2.0"
-  }
+      { proxying =
+          { dependencies = 
+              [ "console"
+              , "effect"
+              , "generics-rep"
+              , "prelude"
+              , "test-unit"
+              , "typelevel-prelude"
+              ]
+          , repo =
+              "https://github.com/matthew-hilty/purescript-proxying.git"
+          , version =
+              "v1.1.0"
+          }
+      , subcategory =
+          { dependencies =
+              [ "prelude", "profunctor", "proxy", "record", "typelevel-prelude" ]
+          , repo =
+              "https://github.com/matthew-hilty/purescript-subcategory.git"
+          , version =
+              "v0.2.0"
+          }
+      }
 
 in  upstream // overrides // additions


### PR DESCRIPTION
Argonaut has had a major version bump which introduces typed errors, so I've updated this library to accommodate the changes. Fortunately it turns out it's only a dev dependency here and the project successfully builds and passes tests without any changes to the code!

While I was making the update I noticed an opportunity to update your Spago file to use the most recent formatting -- Spago doesn't use `mkPackage` anymore. I also noticed that the "private" key was duplicated in your package.json and removed the duplicate for you.

No rush to merge this and it won't require a release because only dev dependencies have changed, but it's ready to go if you'd like to merge.